### PR TITLE
Always show time. Improve compatibility with fasd.

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -18,11 +18,8 @@ function fish_right_prompt
         set -l duration_copy $CMD_DURATION
         set -l duration (echo $CMD_DURATION | humanize_duration)
 
-        echo -sn (set_color $status_color) "$duration" (set_color normal)
-
-    else if set -l last_job_id (last_job_id -l)
-        echo -sn (set_color $status_color) "%$last_job_id" (set_color normal)
-    else
-        echo -sn (set_color 555) (date "+%H:%M") (set_color normal)
+        echo -sn (set_color $status_color) "$duration " (set_color normal)
     end
+
+    echo -sn (set_color 555) (date "+%H:%M") (set_color normal)
 end

--- a/fishfile
+++ b/fishfile
@@ -1,5 +1,4 @@
 fisherman/git_util
 fisherman/pwd_is_home
 fisherman/host_info
-fisherman/last_job_id
 fisherman/humanize_duration


### PR DESCRIPTION
- Always show the time.
- Remove last_job_id since fasd always invokes a job.